### PR TITLE
Fix cryptonight heavy compile for non-x86 hardware

### DIFF
--- a/cn_heavy/cn_slow_hash_hard_intel.cpp
+++ b/cn_heavy/cn_slow_hash_hard_intel.cpp
@@ -40,9 +40,9 @@ extern "C"
 #include "../crypto/c_blake256.h"
 }
 
-namespace cn_heavy {
-
 #ifdef HAS_INTEL_HW
+
+namespace cn_heavy {
 
 #if !defined(_LP64) && !defined(_WIN64)
 #define BUILD32


### PR DESCRIPTION
Tested on Aarch64 platform